### PR TITLE
[docs] Migrate Managed Kubeflow on Azure docs

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -369,5 +369,7 @@ recognized
 walkthrough
 preconfigured
 integrations
+flavor
+flavors
 
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -368,5 +368,6 @@ organization
 recognized
 walkthrough
 preconfigured
+integrations
 
 

--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -357,6 +357,16 @@ containerized
 microservice
 GH
 ServiceAccount
-
+vCPUs
+vGPUs
+customized
+PoC
+CPUs
+CPU
+EntraID
+organization
+recognized
+walkthrough
+preconfigured
 
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -242,7 +242,9 @@ linkcheck_ignore = [
     "https://ubuntu.com/community/ethos/code-of-conduct",
     "https://kserve.github.io/website/0.13/",
     "https://kserve.github.io/website/master/get_started/first_isvc/",
-    "https://developer.hashicorp.com/terraform/language/modules"
+    "https://developer.hashicorp.com/terraform/language/modules",
+    "https://kubernetes.io/docs/reference/access-authn-authz/authorization/#request-attributes-used-in-authorization",
+    "https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/"
     ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -244,7 +244,11 @@ linkcheck_ignore = [
     "https://kserve.github.io/website/master/get_started/first_isvc/",
     "https://developer.hashicorp.com/terraform/language/modules",
     "https://kubernetes.io/docs/reference/access-authn-authz/authorization/#request-attributes-used-in-authorization",
-    "https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/"
+    "https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
+    "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/",
+    "https://opentelemetry.io/docs/collector/",
+    "https://kserve.github.io/website/latest/get_started/first_isvc/#2-create-an-inferenceservice"
+
     ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -234,7 +234,9 @@ linkcheck_ignore = [
     "https://charmhub.io/topics/canonical-observability-stack/reference/best-practices#juju-compatibility",
     "https://www.envoyproxy.io/docs/envoy/v1.27.5/configuration/http/http_conn_man/stats",
     "https://portal.azure.com/*",
-    "https://portal.support.canonical.com/"
+    "https://portal.support.canonical.com/",
+    "https://support-portal.canonical.com/",
+    "https://github.com/kubeflow/kubeflow/blob/48b8643bee14b8c85c3de9f6d129752bb55b44d3/components/profile-controller/controllers/monitoring.go#L25-L45:"
     ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,11 +232,12 @@ linkcheck_ignore = [
     "https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/",
     "https://charmhub.io/grafana-agent-k8s/integrations#*",
     "https://charmhub.io/topics/canonical-observability-stack/reference/best-practices#juju-compatibility",
-    "https://www.envoyproxy.io/docs/envoy/v1.27.5/configuration/http/http_conn_man/stats",
+    "https://www.envoyproxy.io/docs/envoy/v1.27.5/*",
     "https://portal.azure.com/*",
     "https://portal.support.canonical.com/",
     "https://support-portal.canonical.com/",
-    "https://github.com/kubeflow/kubeflow/blob/48b8643bee14b8c85c3de9f6d129752bb55b44d3/components/profile-controller/controllers/monitoring.go#L25-L45:"
+    "https://github.com/kubeflow/kubeflow/blob/48b8643bee14b8c85c3de9f6d129752bb55b44d3/components/profile-controller/controllers/monitoring.go#L25-L45:",
+    "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector"
     ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -237,7 +237,12 @@ linkcheck_ignore = [
     "https://portal.support.canonical.com/",
     "https://support-portal.canonical.com/",
     "https://github.com/kubeflow/kubeflow/blob/48b8643bee14b8c85c3de9f6d129752bb55b44d3/components/profile-controller/controllers/monitoring.go#L25-L45:",
-    "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector"
+    "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector",
+    "https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination",
+    "https://ubuntu.com/community/ethos/code-of-conduct",
+    "https://kserve.github.io/website/0.13/",
+    "https://kserve.github.io/website/master/get_started/first_isvc/",
+    "https://developer.hashicorp.com/terraform/language/modules"
     ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -231,9 +231,9 @@ linkcheck_ignore = [
     "https://ubuntu.com/ai#get-in-touch",
     "https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/",
     "https://charmhub.io/grafana-agent-k8s/integrations#*",
-    "https://charmhub.io/topics/canonical-observability-stack/reference/best-practices#juju-compatibility"
+    "https://charmhub.io/topics/canonical-observability-stack/reference/best-practices#juju-compatibility",
+    "https://www.envoyproxy.io/docs/envoy/v1.27.5/configuration/http/http_conn_man/stats"
     ]
-
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'
 

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -232,7 +232,9 @@ linkcheck_ignore = [
     "https://www.cloudflare.com/learning/access-management/what-is-mutual-tls/",
     "https://charmhub.io/grafana-agent-k8s/integrations#*",
     "https://charmhub.io/topics/canonical-observability-stack/reference/best-practices#juju-compatibility",
-    "https://www.envoyproxy.io/docs/envoy/v1.27.5/configuration/http/http_conn_man/stats"
+    "https://www.envoyproxy.io/docs/envoy/v1.27.5/configuration/http/http_conn_man/stats",
+    "https://portal.azure.com/*",
+    "https://portal.support.canonical.com/"
     ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -237,15 +237,11 @@ linkcheck_ignore = [
     "https://portal.support.canonical.com/",
     "https://support-portal.canonical.com/",
     "https://github.com/kubeflow/kubeflow/blob/48b8643bee14b8c85c3de9f6d129752bb55b44d3/components/profile-controller/controllers/monitoring.go#L25-L45:",
-    "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/#nodeselector",
-    "https://kubernetes.io/docs/concepts/workloads/pods/pod-lifecycle/#pod-termination",
+    "https://kubernetes.io/docs/*",
     "https://ubuntu.com/community/ethos/code-of-conduct",
     "https://kserve.github.io/website/0.13/",
     "https://kserve.github.io/website/master/get_started/first_isvc/",
     "https://developer.hashicorp.com/terraform/language/modules",
-    "https://kubernetes.io/docs/reference/access-authn-authz/authorization/#request-attributes-used-in-authorization",
-    "https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/",
-    "https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/",
     "https://opentelemetry.io/docs/collector/",
     "https://kserve.github.io/website/latest/get_started/first_isvc/#2-create-an-inferenceservice"
 

--- a/docs/explanation/system-architecture.rst
+++ b/docs/explanation/system-architecture.rst
@@ -217,7 +217,7 @@ CKF integrates with various solutions of the `Juju`_ ecosystem.
 
 Charmed MLflow
 ~~~~~~~~~~~~~~
-CKF integrates with the `Charmed MLflow bundle <https://charmhub.io/mlflow>`_ for experiment tracking and as a model registry.
+CKF integrates with `Charmed MLflow <https://charmhub.io/mlflow>`_ for experiment tracking and as a model registry.
 
 .. image:: https://assets.ubuntu.com/v1/7ad21148-cmlflow.png
 
@@ -238,7 +238,7 @@ See `Charmed MLflow documentation <https://documentation.ubuntu.com/charmed-mlfl
 Charmed Feast
 ~~~~~~~~~~~~~
 
-CKF integrates with the `Charmed Feast bundle <https://github.com/canonical/charmed-kubeflow-solutions/tree/track/1.10/modules/kubeflow-feast>`_ to provide a feature store for managing and serving machine learning features across training and inference workflows.
+CKF integrates with `Charmed Feast <https://documentation.ubuntu.com/charmed-feast/>`_ to provide a feature store for managing and serving machine learning features across training and inference workflows.
 
 .. image:: https://assets.ubuntu.com/v1/424d1fb0-cfeast_integration.png
 

--- a/docs/index.rst
+++ b/docs/index.rst
@@ -18,6 +18,7 @@ It is intended for data scientists and ML engineers, providing an advanced toolk
    How to </how-to/index>
    Reference </reference/index>
    Explanation </explanation/index>
+   
 
 In this documentation
 ---------------------

--- a/docs/managed-kubeflow/configure-quotas.rst
+++ b/docs/managed-kubeflow/configure-quotas.rst
@@ -1,0 +1,53 @@
+:orphan:
+
+.. _configure_quotas_azure:
+
+Configure quotas on Azure
+=========================
+
+This guide describes how to configure Azure quotas to set up a Canonical Managed application.
+
+.. note::
+
+   All information needed to change the quota is in the error message.
+
+1. Get started by visiting `the quota page <https://portal.azure.com/#view/Microsoft_Azure_Capacity/QuotaMenuBlade/~/myQuotas>`_.
+2. Find the region where you need additional quota: 
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXfDORUbBI8SwdAXunt8HEZhQOz1BSs6rXvD2SPYaGqtLHoVHwluowUB7qTrS0HJDPtS6Fms76J5L5OnFwy_EkY7fSOH00NDmXQk0TilUDmpWwHs8WoHKcXuz2umx1QU07U6PXw7?key=vfYKUiktMu-Yv0oKyjtkUbdU
+
+3. Use ``Region`` to filter the information in the quota page as shown below:
+
+.. image:: https://assets.ubuntu.com/v1/acb7de82-Azure%20quotas.png
+
+Now that only the CPU families available in that region are shown, request the additional quota for all the CPU/GPU families listed in the error message:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcnZA5LWASDErtsjcGBMDua8kprLXE2fi5jKmCDFmjLCQOUSc7axUaC32BA-Wih43v0FQ3dW4LJ0mkSJvaA9mSB08jV9Q9kV6NizVfKK-aVtdY4LZ__LG6xogC_YoT_Qczzfn7p?key=vfYKUiktMu-Yv0oKyjtkUbdU
+
+4. From the error message, copy the CPU/GPU family:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXffB3aVdKl3J04ylATiT9Wua_uoX00zdqLXcewgoL805ZSEn9dD5DVaNwREW2rtEUbWXPnWVREOqTqW3jdcHLQSq7-DHKLi2bFz_X9o2S_jeKr6UR449zTO042InuMmZxIlwhAk?key=vfYKUiktMu-Yv0oKyjtkUbdU
+
+5. Paste the family in the search box of the quota page:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXd8EeYDZX4lDWmdx5RfS7GFUokIsO-6WX40-Taany354jeE7wLhZzC7GmOuWGNI40TSVhOiCuIzAQNtuFbMQ1Z4J_DQgH154ICy3jPJYIesTw9qH9Fqn2ZbmIof1sMccwYi8tIm?key=vfYKUiktMu-Yv0oKyjtkUbdU
+
+6. Click on the pen icon at the far end of the line, a new screen will appear:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXfxUN9ePtwVVp3Wd_B_YFEcTdRlEs3jBzZ61jRZC_lfzoM7nw4cCCaOuANjngX6vFY0UIClUrauNGuRRKvoaWxfwh46tozxSC_TiLRTjQqfokc0KOZoU7jQl3xUsU3ChsdjosR9?key=vfYKUiktMu-Yv0oKyjtkUbdU
+
+7. Set ``New limit`` to the suggested value:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcxZpJ2o5bU9SQ76W--28IYQ4vbSsq6oS9iJSUGwFriEN_69uluF1aFazaFVcg1SPodECJDYXlAlu5cz1cSkC1rX7cC-rBaL48tGnhJr2onQBYGRB2UwtYGfHMtBbV4MbK1j_H-zQ?key=vfYKUiktMu-Yv0oKyjtkUbdU
+
+8. Click ``Submit`` for the quota to be granted.
+9. Do this for all listed CPU/GPU families within the error message.
+
+You can continue with your setup after all CPU/GPU families have the required quota.
+
+.. note::
+
+   Quota request processing time depends on Microsoft and may vary. 
+   Approval could take anywhere from a few minutes to several days, or your request might be rejected. If Azure doesn’t grant your requested quotas, see `how to request an increase for non-adjustable quotas <https://learn.microsoft.com/en-us/azure/quotas/per-vm-quota-requests#request-an-increase-for-non-adjustable-quotas>`_.
+
+

--- a/docs/managed-kubeflow/enable-microsoft-providers.rst
+++ b/docs/managed-kubeflow/enable-microsoft-providers.rst
@@ -1,0 +1,58 @@
+:orphan:
+
+.. _enable_microsoft_providers:
+
+Enable Microsoft providers
+==========================
+
+This guide describes how to register your ``Microsoft.Capacity``, ``Microsoft.Storage``, 
+and ``Microsoft.Compute`` providers required to set up a Canonical Managed application.
+
+.. important::
+
+   If you are already on the ``Resource Providers`` page, skip to step 4.
+
+1. Go to the Azure ``Subscriptions`` page by searching on the top bar:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXf_L0-kjaW4d944K9njio6O0UAZSFMMnB9Bz0Oiog_Y26KVuLl1-tvwzcjwmOzlCnBu9Q42Qwz8P46lAqX8leIjkv4pMBLWLNpgu7sdVaymrb__p--N06-Q32ivDxG-SDH4JfLRxg?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+2. Click on the subscription you want to use for the setup:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcwLJbEUV38UrUKtkpXVfWeInc8B-tW09JNNa_JiGV-wR8UwuN3757gzMdz0BAChMClHdTN1wI6yuZ8htdaCpUsjiIl6tamUO3Dp1Ofwww2CZNyORKwbyf9k6cq8vmqB9Zuxa9f?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+3. Search for ``providers`` on the menu search box and click on ``Resource Providers``:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXctJdTmKv3B_79pefbrJDgQbfo7OkmIBWB9nZ0bmv2gAj1QJd2ktzzYWR8Z2F5jV_Hd5v252UdUEgfRVoKb5JdjwUsk8lut8ZWceJfMtGjAP-FPDS1QtsstkfZGvZOlykkCZJLMAQ?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+4. Search for ``capacity`` using the ``Filter by name`` field:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcvOk6ODQ2aKm9fHcmGtpY-Svebij_ktHK0h8kdNPCF-kQLM2jKiJnqOs0bCsbDvTxDIt004YxGFq7EBjiycTlbvTc0bCtVJMReTL2j08umOnvPflV70TzkWh8wKqlE0hkCpw22xg?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+5. You should see that ``Microsoft.Capacity`` status is ``notRegistered`` or ``unregistered``:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXdLY6I2cIfqx_y0LolsQ-VeduQ0de4IdZ-EHNcDwiDk0nndi5K_ST3sjK4Hq0sDRNVKjpclQ3EdEIJIS05sQT6-dHEPd1uVOKA8Mfum3xAByF0RBJA4hlnb8FJVGXQaVv42XtiC?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+6. Select it by checking the circle before the name and click ``Register`` on the top:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXd7oyyVR70675FlfKCfliGLgZFEdbscCRyw5GIF47eQvCMGhG9hSvTGM176sOjoC6NRSbWYrTYxfmze9KL03_4BqX0EElJQL2oRc4_LSd_aKS1334pUJtHXbD1qF6iNAfaibwJHMw?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+7. Wait until the provider status changes to ``Registered``:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXebYnd2grfqgqN0YzwPj_C_REsRnzGwEVyJfHg66ItVf1eYouwo97SRot5R0XfB9kTXsmw52BuTiJKgKjvFzHqtAk7G5XCWySO_MdtnkaQ09tvsGM4zt8sr9kSxK1GeOTHZaBJqhg?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+8. Now do the same for ``Microsoft.Compute``.
+9. Search for it using the ``Filter by name``.
+10. Select it by checking the circle before the name, and click the ``Register`` button.
+11. Wait until the provider changes to ``Registered``:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXfAk3p6OiEqu-5aoE3KAWTzDKnGSvAOsYxMK6RjcADnl4ALhcmad7FnDp6Ju6SK5V-abqOhLSpfViraB9OliUrZxs8WO8DvPc7CTA5RDlOrYmJXT4miHvTVhwmwEgxiRcbacfjdLg?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+12. Now do the same for ``Microsoft.Storage``.
+13. Search for it using the ``Filter by name``.
+14. Select it by checking the circle before the name, and click the ``Register`` button.
+15. Wait until the provider changes to ``Registered``:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXeVYgexNeAhjD93qnRMoXH8m1v6oxAXRlLeacesAnxZT3PmLMTGS5UkAezQ4BT34sZjMCgApg6Sn59EjPy233ZgvLy0-C4RFEaq3vP4SZdJHlS152gBRkzW53PrI0icIB3yrsuvTw?key=kZJjKrS7KBF2-Owe_pHRK2w3
+
+16. Once all providers are registered, you need to restart your setup. The easiest way is to close the setup tab in your browser and restart it from the `Azure Marketplace <https://portal.azure.com/#create/canonical.managed-kubeflowkubeflow-metered>`_.
+

--- a/docs/managed-kubeflow/faq.rst
+++ b/docs/managed-kubeflow/faq.rst
@@ -3,8 +3,8 @@
 
 .. _faq_managed_kf:
 
-FAQ for Managed Kubeflow on Azure
-=================================
+Support and FAQ
+===========================
 
 This guide answers some of the most common asked questions about Managed Kubeflow on Azure.
 

--- a/docs/managed-kubeflow/faq.rst
+++ b/docs/managed-kubeflow/faq.rst
@@ -1,0 +1,167 @@
+:orphan:
+:tocdepth: 2
+
+.. _faq_managed_kf:
+
+FAQ for Managed Kubeflow on Azure
+=================================
+
+This guide answers some of the most common asked questions about Managed Kubeflow on Azure.
+
+------------------------------
+What does the service include?
+------------------------------
+
+Canonical offers managed services for every managed application cluster deployed on Azure marketplace. This significantly accelerates time-to-market and ensures operational excellence. The following services are provided:
+
+~~~~~~~~~~~~~~~~~~
+Business-as-usual
+~~~~~~~~~~~~~~~~~~
+
+* Monitoring.
+* Alerting.
+* Integrated observability leveraging `COS <https://ubuntu.com/blog/tag/canonical-observability-stack>`_.
+
+~~~~~~~~~~~~~~
+Planned events
+~~~~~~~~~~~~~~
+
+* Upgrades.
+* Patching.
+* Migration.
+* Cluster scaling.
+* Security hardening.
+
+~~~~~~~~~~~~~~~~~~
+Unplanned events
+~~~~~~~~~~~~~~~~~~
+
+* Incident response.
+* Bug fixing.
+* Backup & restoration.
+
+~~~~~~~~~~~~~~~~~~~~
+Additional services
+~~~~~~~~~~~~~~~~~~~~
+
+* Upstream Kubeflow contributions, such as bug and CVE reports.
+* Automated ticketing system.
+* Multi/hybrid cloud integration and compatibility.
+
+---------------------------------------
+Why do you need an Ubuntu One account?
+---------------------------------------
+
+Ubuntu One is Canonical's identity manager, where every formal interaction with Canonical uses it for authentication. This helps us identify who you are and what our relationship is in a faster and easier way.
+
+.. important::
+
+   When creating your Ubuntu One account, make sure the email address you use matches the email address associated with the Azure account from which you deployed the Managed Kubeflow service.
+
+If you do not use an Ubuntu One account, Canonical will not be able to upgrade or maintain your environments, monitor your usage, bill you adequately, or stay in touch.
+
+--------------------------
+How is the service priced?
+--------------------------
+
+See Canonical's `pricing model <https://pages.ubuntu.com/rs/066-EOV-335/images/Managed%20Apps%20on%20Public%20Cloud%20Pricing%20Explanation%20Datasheet.pdf?version=0&_ga=2.166526398.1658000811.1730716752-1990936172.1718804489>`_ to better understand how our managed services are priced for all managed applications provided on Azure marketplace.
+
+------------------------------------------
+What tools do you get with the deployment?
+------------------------------------------
+
+Your deployment is made up of Charmed Kubeflow and Charmed MLflow:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXfEVULlcLqEJpNN2LxLz1SBFA9tK_DiR_gtsMrXkYuJBNW97uGboVx0NJCqTlYxLhAN9gohtdCKL2oCeBxr63X6fUZUl2BkbFp8PrneMOBT2Lw3EatZSxKll714woy1BCO48Bdp_Q?key=BHCZxQMTEo6n6w4x2fqyLQ
+
+For customised deployments, such as different flavors of the provided applications or integrations with other open source tooling, please `contact our sales department <https://ubuntu.com/managed>`_.
+
+------------------------------------
+Where can you raise issues and bugs?
+------------------------------------
+
+Issues and bugs can only be raised through a support ticket using `Canonical Support Portal <https://support-portal.canonical.com/>`_.
+
+.. important::
+
+   An Ubuntu One account is required to access the portal.
+
+You receive a direct link to the support portal in the welcome email, after your Managed Kubeflow deployment is complete.
+
+----------------------------------
+How do you raise a support ticket?
+----------------------------------
+
+Go to the `Canonical Support Portal <https://support-portal.canonical.com/>`_. Once you're signed in with your Ubuntu One account, click on the ``New Ticket`` button on the portal's homepage:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXdZlS-g1fzcqmp-Isw0Mn6W7jPjngjOoseLCNazWqPSCJ1FZiBMTV3ylWsRKb_iPv7Dq1nItNP5HmcNpeP2xmLmqI4oSprAdr9Ou2dwau-Nisc13fnBV6ymcLDmE_z55wYVL-14ri8tljG7kgeHLZ1W7XEs?key=BHCZxQMTEo6n6w4x2fqyLQ
+
+Follow the steps in the pop-up window to submit your ticket.
+
+---------------------------------------
+How do you transfer out of the service?
+---------------------------------------
+
+You can transfer out of Canonical's managed services on Azure in two different ways:
+
+1. Complete system decommissioning.
+
+   This option involves a complete deletion of your cluster, along with all the data that runs on top of it.
+
+   You can do this directly from Azure marketplace.
+
+2. Managed Services decommissioning.
+
+   With this option, Canonical transfers the resource group management capabilities to your team and will stop managing your clusters after that. Your data and workloads will remain active, and will be transferred to a repository where only you have access and admin rights.
+
+   This option would allow you to continue using your Canonical application, without managed services. Please reach out using `Canonical Support Portal <https://support-portal.canonical.com/>`_ for this request.
+
+----------------------------------------------
+What is the best way to delete the deployment?
+----------------------------------------------
+
+See `Azure documentation <https://learn.microsoft.com/en-us/marketplace/create-manage-private-azure-marketplace-new>`_ for more details.
+
+-------------------------------------------------
+Can you use spot instances with Managed Kubeflow?
+-------------------------------------------------
+
+Yes, you can. See `this guide <https://charmed-kubeflow.io/docs/integrate-with-azure-spot-virtual-machines>`_ to use Charmed Kubeflow with spot instances.
+
+----------------------------------
+How can you scale in or scale out?
+----------------------------------
+
+Your deployment will auto-scale depending on your workload requirements, within the limits you set at the beginning of your deployment. You can change these limits whenever you want on the Azure portal.
+
+If you want to perform a larger scale-in or scale-out transaction, such as a migration or the addition of a separate service, please raise a ticket using `Canonical Support Portal <https://support-portal.canonical.com/>`_.
+
+-------------------------------
+Can you customise the solution?
+-------------------------------
+
+The service provided on Azure marketplace offers a version of Charmed Kubeflow and Charmed MLflow that should cover most of the relevant Machine Learning use cases nowadays. This flavor of Charmed Kubeflow cannot be changed on the marketplace or Microsoft Azure portal.
+
+However, Canonical offers fully customised solutions for any customer via private offering. To obtain a quote for a customized solution, please reach out to our `Sales department <https://ubuntu.com/managed>`_.
+
+-------------------------------------------------
+Can you use your already existing AKS deployment?
+-------------------------------------------------
+
+You cannot since Charmed Kubeflow only works on new deployments.
+
+If you've got a redundant AKS deployment that you wish to run Kubeflow on, Canonical recommends decommissioning it, and starting a new deployment via Azure Marketplace listing. Follow :ref:`this tutorial <install_aks>` to ensure your deployment is properly set up.
+
+----------------------
+Who can you contact?
+----------------------
+
+If you encounter an issue with Azure marketplace listing and offer, or would like to know more details of the offered services, please `reach out to our sales department <https://ubuntu.com/managed>`_.
+If you encounter an issue while deploying the service, please refer to `Managed Kubeflow on Azure documentation <https://charmed-kubeflow.io/docs/managed-kubeflow-on-azure>`_. If your question or problem is not addressed there, get in touch with `support@canonical.com <mailto:support@canonical.com>`_.
+If you have already deployed your managed cluster on Azure, please raise any concern or issue by opening a ticket using `Canonical Support Portal <https://support-portal.canonical.com/>`_.
+
+----------------
+Get further help
+----------------
+
+Contact `Canonical Managed Services <https://ubuntu.com/managed>`_ for any additional questions.

--- a/docs/managed-kubeflow/faq.rst
+++ b/docs/managed-kubeflow/faq.rst
@@ -126,7 +126,7 @@ See `Azure documentation <https://learn.microsoft.com/en-us/marketplace/create-m
 Can you use spot instances with Managed Kubeflow?
 -------------------------------------------------
 
-Yes, you can. See `this guide <https://charmed-kubeflow.io/docs/integrate-with-azure-spot-virtual-machines>`_ to use Charmed Kubeflow with spot instances.
+Yes, you can. See :ref:`this guide <integrate_azure_spot_vms>` to use Charmed Kubeflow with spot instances.
 
 ----------------------------------
 How can you scale in or scale out?
@@ -157,7 +157,9 @@ Who can you contact?
 ----------------------
 
 If you encounter an issue with Azure marketplace listing and offer, or would like to know more details of the offered services, please `reach out to our sales department <https://ubuntu.com/managed>`_.
-If you encounter an issue while deploying the service, please refer to `Managed Kubeflow on Azure documentation <https://charmed-kubeflow.io/docs/managed-kubeflow-on-azure>`_. If your question or problem is not addressed there, get in touch with `support@canonical.com <mailto:support@canonical.com>`_.
+
+If you encounter an issue while deploying the service, please refer to :ref:`Managed Kubeflow on Azure documentation <index_managed_kubeflow>`. If your question or problem is not addressed there, get in touch with `support@canonical.com <mailto:support@canonical.com>`_.
+
 If you have already deployed your managed cluster on Azure, please raise any concern or issue by opening a ticket using `Canonical Support Portal <https://support-portal.canonical.com/>`_.
 
 ----------------

--- a/docs/managed-kubeflow/get-started.rst
+++ b/docs/managed-kubeflow/get-started.rst
@@ -4,3 +4,193 @@
 
 Get started with Managed Kubeflow on Azure
 ==========================================
+
+This guide describes how to get started with Canonical's fully `managed solution <https://ubuntu.com/managed>`_ 
+of Charmed Kubeflow (CKF) running on top of `Microsoft Azure <https://azure.microsoft.com/en-us>`_. 
+It provides supported operation management, deployment, and dedicated customer service.
+
+.. note::
+
+   Watch `this video <https://drive.google.com/file/d/1mHXIrXXSN-XkLJTvMN3991MerRvCFXM0/view?usp=sharing>`_ to find the correct Kubeflow listing in the Azure Marketplace and to see a walkthrough of the installation process.
+
+---------------------
+Requirements
+---------------------
+
+Before starting, ensure you have:
+
+* Admin rights on your Azure tenant.
+  
+  * You might need to create and register an EntraID application. If you are not the sole admin of this account, or if it's owned by an organization, you might encounter permission issues.
+
+* The ``Microsoft.Compute`` and ``Microsoft.Capacity`` resource providers registered.
+
+  * In case they are not, please proceed to register them following `this Microsoft guide <https://discourse.charmhub.io/t/enable-microsoft-capacity-provider/16129>`_. Then, wait for a few hours. Azure takes up to 24h to reconcile this change. If you try to deploy right after enabling the providers, you might encounter quota verification issues.
+
+.. note::
+
+   If you encounter quota limits for your preferred VM size, you will be prompted to request a quota increase. 
+   Azure generally grants the request fairly quickly, but you need to **restart** the Kubeflow deployment wizard afterwards; otherwise, your new quota limits might not be recognized.
+
+-------------------------
+Access Azure Marketplace
+-------------------------
+
+Visit `Azure Marketplace <https://portal.azure.com/#create/canonical-test.managed-kubeflow-previewkubeflow-metered>`_ to find Canonical's Managed Kubeflow offering.
+
+You will find all the information about the application, available plans and pricing, reviews, and more.
+
+1. Get started by clicking ``Create``.
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXei-xKqwkmbxKNwA9AJX2zrEkWOXYjan4TkpnxgkSm_KU6ygVf3m1xVE4igR9zJPP2biyTPmjgjW09q6KLu-OpSgDQH3LT-LlOCBY2_5igbaDjBvcRRfr4iX5-8ZxhofiEFNBC8xA?key=l078tT9me2KL1Tam4ou9ZQ
+
+-----------------------------
+Configure Kubeflow parameters
+-----------------------------
+
+Configure some Kubeflow parameters based on your needs by following these steps:
+
+1. Start by selecting a subscription and a resource group name (create a new one if needed). This is where Kubeflow is set up:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXejXG_GOupxKTIFRVSPnUbnSbzvBezmEd9imNG_tjSXqBE7-NClhcCjRBtU59uhRRJM0NTfi_SaecYsvqXI18Bn6l59uBOG0XhI9wIjdgsXgoSuti2-IgVD-xj8o7uPXHln2a1R5w?key=l078tT9me2KL1Tam4ou9ZQ
+
+2. In the Instance details section, select the region:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcqO4bXtR88WS4gfYbp8ga9wAh9xudb9OkdZBIGBeT_F0faAxxkItyGVXdEcm6Fb38Mi9APCrGi1_v_m4iBAsoeszJSGvuiDwJlrNJHHIF6Gu0fmWPXkTL13P5ApaB2FA7nFym0?key=l078tT9me2KL1Tam4ou9ZQ
+
+3. Insert your contact information:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXd0HMKfTnJzZeACwdxSmlftX9jKZkyTS3TK-PhkEQ63wIf0HaOx-p3pgN1wLMQ2ll293xuToMUP-LFVvVmJHXykRTQFrlQCHXHDViiaTyy_F_kyhk_-qYqFvnmh1NcIsSi05OE9?key=l078tT9me2KL1Tam4ou9ZQ
+
+4. Insert the application name and its managed resource group that will contain the managed service. You can leave the latter field as is by default:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXfmhHp4EdVgfTTQKEMTuYYDxtRDroJA2FDbjMU5fCcPCQlyTS4Kzlx-tVm9vgSmho-KRM_MX07-U1bzC9LYUHXFSQRsco26s7Fo_J9SzmAiwKoEkafsu5MbXMBFpT7XeD1CvD8uPQ?key=l078tT9me2KL1Tam4ou9ZQ
+
+5. Once completed, click ``Next``.
+
+-----------------------
+Configure your Kubeflow
+-----------------------
+
+You can now configure your Kubeflow instance.
+
+.. note::
+
+   In case you see this warning box:
+
+   .. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXfpjHt8yLGQ5x88Ajs-jwwxbDuKDTlTlETfH-H2f61g7gD9PwkVShxwOHG4dFR7SH-W9dh2G30TlOgAzbFoJYUZXx3K367SAxuqZ0xmV-wjpOfe7LZum3m00eYIRKeXbSHm-2EnTA?key=l078tT9me2KL1Tam4ou9ZQ
+
+   You need to enable those Microsoft resource providers for the setup to be able to check your vCPUs/vGPUs quotas. Refer to the guide provided in the warning box for more details.
+
+1. Choose if you want to enable or disable High Availability (HA):
+
+   HA provides the reliability needed for production and high-workload environments. Disabling it will allow you to save on costs, but the environment will be less reliable as the management services will run without redundancy.
+
+.. note::
+
+   Enabling HA is recommended for production environments, while disabling it for development and testing environments is acceptable.
+
+2. Choose the management instance size you prefer. The size shown below is just for reference:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXd8vbTHPYWxMi3TiPpLkv2mn6LmeYL_ns-HyCNxK91q3u0iefbZC4RF5LzlcKFf3wZIVZlsvewNeBuDosZ5Rsw0gu2FWvRp7Tt38tgny0I_1KtAWyzItuGqn_AE8oB8YqkmfPfA6A?key=l078tT9me2KL1Tam4ou9ZQ
+
+The use of GPUs for the management instances is not recommended. In most cases, the suggested size is enough.
+
+.. warning::
+    The system automatically checks if the required quota for the setup is allowed in your Azure tenant. If it's not, the procedure generates a message containing all the information needed to increase your quota before continuing with the setup. Please, follow those instructions.
+
+Configure now the worker pools.
+Worker pools are a way to have different workloads on different types of CPUs and GPUs, so that the least important tasks may run on the cheapest GPUs, 
+while highly important tasks are performed on the fastest ones.
+
+You can independently allocate the worker pools for different purposes. 
+For example, you might allocate a worker pool of vCPUs for trivial development tasks or to work on a PoC, 
+while a worker pool of powerful vGPUs works on training machine learning models.
+
+.. note::
+
+   After the deployment is complete, you can add and remove worker pools by contacting Canonical's support.
+
+This deployment allows up to four worker pools with different CPU or GPU sizes for different workloads, and each worker pool automatically scales between the minimum and maximum values you choose.
+
+3. Use the slider to select up to four pools.
+4. For each pool, you can configure its name, the worker size, and the workers range Kubeflow will use. The size shown below is just for reference:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXd7nmBJKrVNrjMzkAwsdY160Tc1LE2hAH4a7IRHX87Ah7NXL5HABI5GgIpW2O6eOuusJXrpuQoixi3-5wfRyD8l275tbs02mYPJyq4G60zmPrTdh1xHV2h-FPiOg1cL47Q5PXLH?key=l078tT9me2KL1Tam4ou9ZQ
+
+Depending on your setup purpose, choose between vCPUs or vGPUs. vGPUs are recommended for production environments.
+
+.. warning::
+    The system automatically checks if the required quota for the setup is allowed in your Azure tenant. If it's not, the procedure generates a message containing all the information needed to increase your quota before continuing with the setup. Please, follow those instructions.
+
+5. Once all pools are configured and the quotas are all set, click Next.
+
+---------------------
+Configure access
+---------------------
+
+To configure access, you can choose between filling the values with your own OpenID parameters or creating new access credentials based on Azure Entra ID:
+
+If you choose Azure Entra ID, follow the steps below to generate the following required values:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXdQXRTg3yaRFUx91TmTwLFIoQuH0QjkubBuJxn77X4gcu2n2y7IkU299Gnl8LsYHtmGOK1oDaWfkzYM59hROhxCtpUIL0rl9IGKho4zqeIwRhfOJbBt2GALzt_eCtABguJYOe3TNg?key=l078tT9me2KL1Tam4ou9ZQ
+
+1. To register a new App, copy the ``OpenID Redirect URL`` from the page you are in:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXd_-BJ-2Lkjzuv-vLxwWUjl5v6OBF9eogKUAP6V3MUpOw6YPEuK7bsWHGnyNQaYONc-qjVwU-fSYIU95IogGUZtGG0YU8W9JG2dLU-anMwv_G5rX2r50DgGRB-4ukrbW-dl7wsAQQ?key=l078tT9me2KL1Tam4ou9ZQ
+
+2. Open the link in the information box:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXd1Ltt5-ms1at9zDMw78fo3DC7BE8stRdo6prd6i7Kqaw_NEaB3vZ1tiy0ScsLHfh3sw8W-qAmMgRLCn743dk-DZ-HBceDAcwCL2Mj2FrtXO7j31zO4yCGRQqpms-PPseMEPWP9?key=l078tT9me2KL1Tam4ou9ZQ
+
+3. Choose the Entra ID application name. It can be different from the application name you chose earlier for the deployment:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXfL2c-pGZoKpzPA-hknb9LgCf8z6ghY3cAPSRDmF6J04unOcw8yBlXuCNDIW8R8SjIxr4JQuEBaPUM0iDLoQXA4l1_J9URDlKyYxjz9_ilTV4o7zluCDlyEOPIx5YL6h7sIZFpubA?key=l078tT9me2KL1Tam4ou9ZQ
+
+4. Choose ``Web`` in the ``Redirect URI`` combo box and paste the ``OpenID Redirect URL`` in the text box:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcd0-Zm1UxFi5JSnYpEWrowr7E9Ao0uJJ_d_YcfFEB2WGIdbNHaFqziAuCbOcMi_xn-frMC5xj92AnMXsbXLiKIOvpUuFugQ5O-bbx3pxMuxrDcDbrOAzvhMdUL2MOosREFbka7cQ?key=l078tT9me2KL1Tam4ou9ZQ
+
+5. Click ``Register`` to complete the registration, leaving the other parameters as they are.
+
+6. Refer to `App Registrations <https://portal.azure.com/#view/Microsoft_AAD_IAM/ActiveDirectoryMenuBlade/~/RegisteredApps>`_ and, on that page, click on the app you just created. You can find it by the name.
+
+7. Now copy and paste the ``Application (client) ID`` into the ``Client ID`` field back in the deployment tab:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXceVRNpd9MLUTrJOu1ghgeVJ0m7zJDY9qKnTTxB6SpBt4Fvdq4sp5yAN78O0sCH6h0tHzGjsIaLIFFKONLXUYGV4sE_ofF9IuWarPrHj8lMe_f6W-TyCOd-71XH6HmTZi-8lDdL?key=l078tT9me2KL1Tam4ou9ZQ
+
+8. Collect the ``Client Secret`` by clicking on ``Manage`` on the left-side navigation bar, and then on ``Certificates & secrets``, then click ``+ New client secret``.
+
+9. Add a description and click ``Add`` to create the secret. Optionally you can choose one year as the expiring time:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXdojW66JByzzMcCcqlBmyUcAwzw7NJGzH6yJjPPt20kTVjRu4SHfxiiWGkc5qkLw6lQRhr6kVj8vLE8IG49Qf0LgpedcVr9WMPFrw9xV2yiV37KDRKJ_iNH64ttXA60CD8Y5I6b2A?key=l078tT9me2KL1Tam4ou9ZQ
+
+10. Copy and paste the secret's ``Value`` into the ``Client Secret`` field back in the deployment tab:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXeeuXRx1ZdT4k2YEdswBlCw2vlOFmqYbGNHdyIplWpgo6qkl8YvwNumSxE5-1FYG1uRlxLdVX_aerMBg3tC6GTma7HH1DqXFwJWurzUpAQEU7AArVME8XQu4G_eakDG1o2yS1V46g?key=l078tT9me2KL1Tam4ou9ZQ
+
+11. Now all fields are compiled, the Entra ID configuration page should look like this:
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXcZVqtmdI8f_dV4teMKXUDR5T25VaeItbhdjxPOy8cdEWlwAKoFVi96Hk53xU22vIMt9jRN5AQvu3B5wgYXdz0EF81meQDmdo86GBzJXOcneEvbQvQUXRfsleJe6gg_m9OfkhWKPA?key=l078tT9me2KL1Tam4ou9ZQ
+
+12. Click ``Next`` to go to the review page.
+
+---------------------
+Review and submit
+---------------------
+
+1. Check and agree with the terms and conditions.
+2. Click ``Create`` to finish the configuration and start the setup.
+
+.. note::
+
+   The setup should take between 15 and 60 minutes. 
+   Once completed, you will be notified via email from `canonical.com <mailto:noreply+portal+managed@canonical.com>`_ which will give you all the links and information to start using your setup. If you cannot find it, please check your Spam folder.
+
+---------------------
+Get further help
+---------------------
+
+You can `contact Canonical Managed Services <https://ubuntu.com/managed>`_ for customized deployments if you are a new user.
+
+You can also visit the `Support portal <https://portal.support.canonical.com/>`_ or `contact our Support team if you are an existing user <https://canonical.com/contact-us>`_. You will be asked to provide your Ubuntu One account details, your subscription date, and the email address associated with the deployment.

--- a/docs/managed-kubeflow/get-started.rst
+++ b/docs/managed-kubeflow/get-started.rst
@@ -1,0 +1,6 @@
+:orphan:
+
+.. _get_started_managed_kf:
+
+Get started with Managed Kubeflow on Azure
+==========================================

--- a/docs/managed-kubeflow/index.rst
+++ b/docs/managed-kubeflow/index.rst
@@ -30,4 +30,8 @@ Read about the node pool configuration in Managed Kubeflow deployments:
    Node scheduling architecture <node-scheduling-architecture>
  
 Get answers to the most common asked questions:
-- [FAQ](/t/16761)
+
+.. toctree::
+   :maxdepth: 1
+
+   FAQ <faq>

--- a/docs/managed-kubeflow/index.rst
+++ b/docs/managed-kubeflow/index.rst
@@ -14,12 +14,20 @@ This solution provides supported operation management, deployment, and dedicated
 
    Get started with Managed Kubeflow <get-started>
 
-Learn how to configure your Canonical managed application:
-- [Set up Azure quotas](/t/16128)
-- [Enable Microsoft providers](/t/16129)
+Learn how to set up your Canonical managed application:
+
+.. toctree::
+   :maxdepth: 1
+
+   Configure Azure quotas <configure-quotas>
+   Enable Microsoft providers <enable-microsoft-providers>
 
 Read about the node pool configuration in Managed Kubeflow deployments: 
-- [Node scheduling architecture](/t/17736)
+
+.. toctree::
+   :maxdepth: 1
+
+   Node scheduling architecture <node-scheduling-architecture>
  
 Get answers to the most common asked questions:
 - [FAQ](/t/16761)

--- a/docs/managed-kubeflow/index.rst
+++ b/docs/managed-kubeflow/index.rst
@@ -1,0 +1,25 @@
+:orphan:
+
+.. _index_managed_kubeflow:
+
+Managed Kubeflow on Azure
+=========================
+
+Canonical offers a fully `managed solution <https://ubuntu.com/managed>`_ of Charmed Kubeflow (CKF) running on top of `Microsoft Azure <https://azure.microsoft.com/en-us>`_. 
+
+This solution provides supported operation management, deployment, and dedicated customer service.
+
+.. toctree::
+   :maxdepth: 1
+
+   Get started with Managed Kubeflow <get-started>
+
+Learn how to configure your Canonical managed application:
+- [Set up Azure quotas](/t/16128)
+- [Enable Microsoft providers](/t/16129)
+
+Read about the node pool configuration in Managed Kubeflow deployments: 
+- [Node scheduling architecture](/t/17736)
+ 
+Get answers to the most common asked questions:
+- [FAQ](/t/16761)

--- a/docs/managed-kubeflow/node-scheduling-architecture.rst
+++ b/docs/managed-kubeflow/node-scheduling-architecture.rst
@@ -1,0 +1,75 @@
+:orphan:
+
+.. _node_scheduling_architecture:
+
+Node scheduling architecture
+============================
+
+This guide provides an overview of the different `Node pools <https://learn.microsoft.com/en-us/azure/aks/create-node-pools>`_, and their configurations, 
+created with :ref:`Managed Kubeflow on Azure <index_managed_kubeflow>` deployments.
+
+---------------------
+System node pool
+---------------------
+
+By default, a system node pool is created for the Managed Kubeflow installation. 
+This node pool hosts all the `Pods <https://kubernetes.io/docs/concepts/workloads/pods/>`_ required for the core control plane of Charmed Kubeflow (CKF).
+These nodes, along with their charmed workloads, are managed by Canonical, ensuring CKF control plane is always up and running.
+
+While a default recommended size is preconfigured, you can still configure Virtual Machine (VM) sizes using the ``Management instance size`` section.
+
+.. note::
+
+   The system node pool does not include any `Taints <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>`_. 
+   The control-plane charms allow ``NodeAffinities`` to be scheduled on those nodes, but other (user) workloads are deployed in the system node pool by default.
+
+---------------------
+Workload node pools
+---------------------
+
+Workload node pools, also known as worker pools, are deployed alongside the system node pool. 
+They are used to schedule workload Pods, such as Notebooks, Pipeline steps, Inference Services, and Katib Jobs.
+
+Every worker pool provides Taints, allowing workload Pods that are explicitly configured to be scheduled on them.
+
+.. note::
+
+   If a workload Pod is not configured with the appropriate Tolerations and Affinities, it could be scheduled on the system node pool.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~
+List workload node pools
+~~~~~~~~~~~~~~~~~~~~~~~~~
+
+You can list the available workload node pools using the Notebooks User Interface (UI). 
+To do so, follow these steps:
+
+1. Navigate to ``Notebooks`` using the left sidebar of the Kubeflow dashboard.
+2. Click on ``+ New Notebook``.
+3. Scroll down.
+4. Click on ``Advanced Options > Affinity / Tolerations``.
+
+There, the list of Affinities provides an entry for every viable node group in the cluster.
+
+.. note::
+
+   All workload node pools include a `Taint <https://kubernetes.io/docs/concepts/scheduling-eviction/taint-and-toleration/>`_ with ``key: sku`` and ``value: <name-of-pool>``.
+
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Schedule workload node pools
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+Workload node pools are configured with default Taints, meaning any Pods intended for these pools must specify matching Tolerations.
+
+By default, Notebooks are automatically configured with Affinities and Tolerations, targeting the first created workload node pool, 
+ensuring Notebook Pods are scheduled correctly.
+However, workloads initiated from Notebooks must explicitly define appropriate Affinities and Tolerations. 
+Without these settings, such workloads will default to the system node pool, which is intentionally resource-constrained. 
+As a result, workloads without the correct configuration may remain in a pending state indefinitely.
+
+.. image:: https://lh7-rt.googleusercontent.com/docsz/AD_4nXc86CuLTHkqAXLXd6uJkZVCw1vYQSJP7svM7pEcLZwRHGjgqMVnYLReuTTOQR3YgiDGTYREOASZ_jBOFVpWziLumjZ_hOqeow9U-WZPZUyHFDRYTMu3GUzPNMX-EIEP8k5dshX4Nw?key=VDlSMFpcrq3z3bKXaVGgJg
+
+For more details on how workload Pods can be configured, see the following guides:
+
+1. :ref:`Schedule Pods on GPU nodes <use_nvidia_gpus>`.
+2. :ref:`Scheduling patterns in Charmed Kubeflow <workload_scheduling_patterns>`.
+3. :ref:`Configure scheduling for Kubeflow workloads <configure_advanced_scheduling>`.

--- a/docs/reference/monitoring/loki-logs.rst
+++ b/docs/reference/monitoring/loki-logs.rst
@@ -88,7 +88,7 @@ Katib-controller
 
 You can check its logs through the Grafana UI using the query ``{pebble_service="katib-controller", charm="katib-controller"}``.
 
-See `Katib-controller logs source <https://github.com/kubeflow/katib/blob/master/cmd/katib-controller>`_ for more details.
+See `Katib-controller logs source <https://github.com/kubeflow/katib/tree/master/cmd/katib-controller/v1beta1>`_ for more details.
 
 ~~~~~~~~~~~~~~~~~~~
 Katib-db-manager
@@ -98,7 +98,7 @@ Katib-db-manager
 
 You can check its logs  through the Grafana UI using the query ``{pebble_service="katib-db-manager", charm="katib-db-manager"}``.
 
-See `Katib-db-manager logs source <https://github.com/kubeflow/katib/blob/master/cmd/db-manager>`_ for more details.
+See `Katib-db-manager logs source <https://github.com/kubeflow/katib/tree/master/cmd/db-manager/v1beta1>`_ for more details.
 
 ~~~~~~~~~~~~~~~~~~~
 Katib-ui

--- a/docs/reference/monitoring/loki-logs.rst
+++ b/docs/reference/monitoring/loki-logs.rst
@@ -128,7 +128,7 @@ Kfp-metadata-writer
 
 You can check its logs through the Grafana UI using the query ``{pebble_service="kfp-metadata-writer", charm="kfp-metadata-writer"}``.
 
-See `Kfp-metadata-writer logs source <https://github.com/kubeflow/pipelines/blob/master/backend/metadata_writer>`_ for more details.
+See `Kfp-metadata-writer logs source <https://github.com/kubeflow/pipelines/tree/master/backend/metadata_writer>`_ for more details.
 
 ~~~~~~~~~~~~~~~~~~~
 Kfp-persistence

--- a/docs/reference/monitoring/prometheus-metrics.rst
+++ b/docs/reference/monitoring/prometheus-metrics.rst
@@ -215,7 +215,7 @@ Training operator
 
 The ``training-operator`` provides the following metrics:
 
-* Custom job-related metrics. See `Training operator source code <https://github.com/kubeflow/training-operator/blob/f8f7363eb905757e7c05321ec8df81aed61cf6c6/pkg/common/metrics.go#L24-L60>`_ for more details.
+* Custom job-related metrics. See `Training operator source code <https://github.com/kubeflow/trainer>`_ for more details.
 * `Go runtime and process metrics <https://pkg.go.dev/runtime/metrics#hdr-Supported_metrics>`_ for monitoring the controller.
 * `Controller runtime <https://book.kubebuilder.io/reference/metrics-reference>`_ metrics.
 

--- a/docs/reference/monitoring/prometheus-metrics.rst
+++ b/docs/reference/monitoring/prometheus-metrics.rst
@@ -117,12 +117,12 @@ Kfp api
 The ``kfp-api`` provides the following metrics:
 
 * Custom metrics related to its several components. See its source code for more details:
-* `Resource manager <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/resource/resource_manager.go#L51-L77>`_.
-* `Experiment server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/experiment_server.go#L34-L73>`_.
-* `Job server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/job_server.go#L34-L72>`_.
-* `Pipeline server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/pipeline_server.go#L37-L94>`_.
-* `Pipeline upload <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/pipeline_upload_server.go#L48-L60>`_.
-* `Run server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/run_server.go#L36-L92>`_.
+* `Resource manager <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/resource/resource_manager.go>`_.
+* `Experiment server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/experiment_server.go>`_.
+* `Job server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/job_server.go>`_.
+* `Pipeline server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/pipeline_server.go>`_.
+* `Pipeline upload <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/pipeline_upload_server.go>`_.
+* `Run server <https://github.com/kubeflow/pipelines/blob/33db1284f57b5b277c95d4a44b35b1fdd830bd18/backend/src/apiserver/server/run_server.go>`_.
 * `Go runtime and process metrics <https://pkg.go.dev/runtime/metrics#hdr-Supported_metrics>`_ for monitoring the controller.
 
 You can check its metrics through the Prometheus or Grafana UI using the following query:
@@ -270,7 +270,7 @@ Profile controller
 
 The ``profile-controller`` provides the following metrics:
 
-* Custom job-related metrics. See `Profile controller source code <https://github.com/kubeflow/kubeflow/blob/48b8643bee14b8c85c3de9f6d129752bb55b44d3/components/profile-controller/controllers/monitoring.go#L25-L45>`_ for more details.
+* Custom job-related metrics. See `Profile controller source code <https://github.com/kubeflow/kubeflow/tree/48b8643bee14b8c85c3de9f6d129752bb55b44d3/components/profile-controller>`_ for more details.
 * `Go runtime and process metrics <https://pkg.go.dev/runtime/metrics#hdr-Supported_metrics>`_ for monitoring the controller.
 
 You can check its metrics through the Prometheus or Grafana UI using the following query:


### PR DESCRIPTION
This PR is migrating Managed Kubeflow on Azure content from https://charmed-kubeflow.io/docs/managed-kubeflow-on-azure to the new repo.

It also fixes some broken links and other config needed. 