### PR TITLE
fix: remove versioning from sitemap

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'charmed-kubeflow'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -182,11 +182,7 @@ html_baseurl = 'https://documentation.ubuntu.com/charmed-kubeflow/'
 # URL scheme. Add language and version scheme elements.
 # When configured with RTD variables, check for RTD environment so manual runs succeed:
 
-if 'READTHEDOCS_VERSION' in os.environ:
-    version = os.environ["READTHEDOCS_VERSION"]
-    sitemap_url_scheme = '{version}{link}'
-else:
-    sitemap_url_scheme = 'MANUAL/{link}'
+sitemap_url_scheme = '{link}'
 
 # Include `lastmod` dates in the sitemap:
 


### PR DESCRIPTION
Docs no longer use versioning in URL scheme, this change fixes the addresses of the pages in the sitemap.

Also adds slug config to fix 404 pages.