### PR TITLE
Specify slug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'charmed-kubeflow'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/


### PR DESCRIPTION
This is required for the notfound extension to function correctly and render a valid page on encountering a 404 error.

Addresses the issue raised [here](https://chat.canonical.com/canonical/pl/z435uy16k3yp8x6z3zhuamupky) in the mm docs channel.