### PR TITLE
[docs] Configure slug

### DIFF
--- a/docs/conf.py
+++ b/docs/conf.py
@@ -169,7 +169,7 @@ html_theme_options = {
 # TODO: If your documentation is hosted on https://docs.ubuntu.com/,
 #       uncomment and update as needed.
 
-# slug = ''
+slug = 'charmed-kubeflow'
 
 #######################
 # Sitemap configuration: https://sphinx-sitemap.readthedocs.io/

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -246,8 +246,9 @@ linkcheck_ignore = [
     "https://opentelemetry.io/docs/collector/",
     "https://kserve.github.io/website/latest/get_started/first_isvc/#2-create-an-inferenceservice",
     "https://github.com/canonical/istio-operators/blob/main/charms/istio-pilot/src/manifests/virtual_service.yaml.j2",
-    "https://dexidp.io/docs/connectors/"
-    ]
+    "https://dexidp.io/docs/connectors/",
+    "https://lh7-rt.googleusercontent.com/docsz/*"
+]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'
 

--- a/docs/how-to/manage/enable-https.rst
+++ b/docs/how-to/manage/enable-https.rst
@@ -33,7 +33,6 @@ Obtain a TLS certificate
 * `AWS Certificate Manager <https://aws.amazon.com/certificate-manager/>`_.
 * `Azure Key Vault Certificates <https://docs.microsoft.com/en-us/azure/key-vault/certificates/>`_.
 * `Google Cloud Certificate Manager <https://cloud.google.com/certificate-manager/docs/overview>`_.
-* `Let's Encrypt (for free certificates) <https://letsencrypt.org/getting-started/>`_.
 * `Self-Signed Certificates <https://www.openssl.org/>`_.
 
 -----------------------------------


### PR DESCRIPTION
This is required for the `notfound` extension to function correctly and render a valid page on encountering a 404 error.

Addresses the issue raised [here](https://chat.canonical.com/canonical/pl/z435uy16k3yp8x6z3zhuamupky) in the mm docs channel.