### PR TITLE
fix: Fix indentation in the Use NVIDIA GPUs how-to guide

### DIFF
--- a/docs/how-to/use/use-nvidia-gpus.rst
+++ b/docs/how-to/use/use-nvidia-gpus.rst
@@ -152,8 +152,8 @@ For example, the inference service YAML file from `this example <https://kserve.
             name: sklearn
             storageUri: "gs://kfserving-examples/models/sklearn/1.0/model"
             resources:
-            limits:
-                nvidia.com/gpu: 1
+                limits:
+                    nvidia.com/gpu: 1
 
 ~~~~~~~~~~~~~~~~~~~
 Within a notebook


### PR DESCRIPTION
Closes #41

This PR is a small indentation fix for the [Use NVIDIA GPUs how-to guide](https://documentation.ubuntu.com/charmed-kubeflow/latest/how-to/use/use-nvidia-gpus/).