### PR TITLE
fix: use correct Katib versions in upgrade

### DIFF
--- a/docs/how-to/manage/upgrade/upgrade-1.10-1.11.rst
+++ b/docs/how-to/manage/upgrade/upgrade-1.10-1.11.rst
@@ -114,9 +114,9 @@ Upgrade the rest of the charms to their current stable versions with ``juju refr
    juju refresh envoy --channel 2.4/stable
    juju refresh jupyter-controller --channel 1.10/stable
    juju refresh jupyter-ui --channel 1.10/stable
-   juju refresh katib-controller --channel 0.18/stable
-   juju refresh katib-db-manager --channel 0.18/stable
-   juju refresh katib-ui --channel 0.18/stable
+   juju refresh katib-controller --channel 0.19/stable
+   juju refresh katib-db-manager --channel 0.19/stable
+   juju refresh katib-ui --channel 0.19/stable
    juju refresh kfp-api --channel 2.15/stable
    juju refresh kfp-metadata-writer --channel 2.15/stable
    juju refresh kfp-persistence --channel 2.15/stable


### PR DESCRIPTION
This PR fixes the Katib version in upgrade guide from `1.10` to `1.11`.