### PR TITLE
docs: add guide to install CKF + Canonical Identity Platform Terraform solution

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -198,6 +198,12 @@ eventing
 api
 API
 otel
+CoreDNS
+hostnames
+iam
+Kratos
+MetalLB
+PMR
 runtime
 SeldonWebhookError
 SeldonUnfinishedWorkIncrease

--- a/docs/how-to/install/index.rst
+++ b/docs/how-to/install/index.rst
@@ -36,4 +36,5 @@ Explore other installation use cases:
     Install behind a web proxy <install-web-proxy> 
     Install on NVIDIA DGX <install-nvidia-dgx>
     Install using Terraform <install-terraform>
+    Install with Canonical Identity Platform using Terraform <install-terraform-identity>
     Install for advanced node-pool scheduling <install-for-advanced-scheduling>

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -1,0 +1,269 @@
+.. _install_terraform_identity:
+
+Install with Canonical Identity Platform using Terraform
+========================================================
+
+This guide describes how to install Charmed Kubeflow (CKF) integrated with the
+`Canonical Identity Platform <https://charmhub.io/topics/canonical-identity-platform>`_ using `Terraform`_.
+
+This solution runs CKF on the `Istio Ambient Mesh`_ and wires it to the Canonical Identity Platform
+(Hydra, Kratos and the Login UI) so that authentication is handled by the Identity Platform.
+
+.. note::
+
+   This integration is available in Istio ambient mode only.
+
+The deployment spans four `Juju models <https://juju.is/docs/juju/model>`_:
+
+* ``istio-system``: the Istio ambient control plane (``istio-k8s``).
+* ``iam``: the Canonical Identity Platform bundle (Hydra, Kratos and the Login UI).
+* ``iam-core``: the Identity Platform dependencies (``postgresql-k8s``, ``traefik`` and ``self-signed-certificates``).
+* ``kubeflow``: the CKF applications, the two ambient ingress gateways (UI and machine-to-machine) and the Identity Platform authentication charms.
+
+.. TODO: Update this guide once the ``feat/iam-integration`` branch of charmed-kubeflow-solutions is merged, including the repository URL, branch and module path.
+
+---------------------
+Requirements
+---------------------
+
+* A K8s cluster version supported by Charmed Kubeflow (see :ref:`Supported versions <supported_kubeflow_versions>`) with a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ configured.
+* A load balancer provider on the cluster, so that the ingress gateways and the Identity Platform can be exposed through ``LoadBalancer`` services. For example, `MetalLB <https://metallb.io/>`_ on `MicroK8s`_.
+* A K8s cluster that meets the `Istio platform prerequisites`_ for the ambient mesh.
+* `Terraform CLI <https://developer.hashicorp.com/terraform/cli>`_. You can install it using the `snap`_.
+* `kubectl <https://kubernetes.io/docs/reference/kubectl/>`_ configured to access your cluster.
+
+---------------------
+Bootstrap Juju
+---------------------
+
+CKF is deployed to Kubernetes with Juju.
+Before deployment, Juju must be bootstrapped to the K8s cluster.
+See `Get started with Juju <https://documentation.ubuntu.com/juju/latest/tutorial/>`_ for more details.
+
+.. note::
+
+   Check :ref:`Supported versions <supported_kubeflow_versions>` for version compatibility between CKF, Juju and K8s.
+
+-------------------------------------
+Deploy CKF with the Identity Platform
+-------------------------------------
+
+Deploy the solution as follows:
+
+1. Clone the repository and change directory to the solution module:
+
+.. code-block:: bash
+
+   git clone https://github.com/canonical/charmed-kubeflow-solutions
+   cd charmed-kubeflow-solutions
+   git checkout feat/iam-integration
+   cd terraform-refactoring/tests/kubeflow-ambient-iam
+
+2. Initialise Terraform. The following command downloads all the required `Terraform modules <https://developer.hashicorp.com/terraform/language/modules>`_ and installs the Terraform `Juju provider <https://registry.terraform.io/providers/juju/juju/latest/docs>`_:
+
+.. code-block:: bash
+
+   terraform init
+
+3. Prepare a Profile Management Repository (PMR).
+
+The ``github-profiles-automator`` charm keeps the Kubeflow profiles in sync with a ``pmr.yaml`` file stored in a GitHub repository.
+Create a repository (for example, ``https://github.com/example-org/kubeflow-pmr``) containing a ``pmr.yaml`` file at its root, such as:
+
+.. code-block:: yaml
+
+   profiles:
+   - name: ml-engineering
+     owner:
+       kind: User
+       name: user1
+
+.. note::
+
+   The profile ``owner.name`` must match the Kratos username you create in the :ref:`Create a user <create_user_identity>` section.
+   In this solution, the profile owner maps to the Identity Platform (Kratos) username, not to an email address.
+
+   See :ref:`Manage profiles <manage_profiles>` for the full ``pmr.yaml`` format, including contributors and resource quotas.
+
+4. Configure the ``github-profiles-automator`` charm to sync from your PMR repository by creating a ``terraform.tfvars`` file in the current directory:
+
+.. code-block:: terraform
+
+   # github-profiles-automator: sync Kubeflow profiles from this PMR repository.
+   github_profiles_automator_config = {
+     repository = "https://github.com/example-org/kubeflow-pmr.git"
+   }
+
+.. note::
+
+   Terraform automatically loads ``terraform.tfvars`` during ``terraform apply``.
+
+5. Define the external hostnames for the ingress gateways and the Identity Platform:
+
+.. code-block:: bash
+
+   UI_HOSTNAME="ui.kubeflow.com"
+   API_HOSTNAME="api.kubeflow.com"
+   AUTH_HOSTNAME="auth.kubeflow.com"
+
+.. note::
+
+   These hostnames do not need to be registered with a public DNS provider. You make them resolvable in the :ref:`Configure DNS for the ingress gateways <configure_dns_identity>` section below.
+
+6. Deploy the solution using Terraform as follows:
+
+.. code-block:: bash
+
+   terraform apply \
+      -var external_ui_hostname="${UI_HOSTNAME}" \
+      -var external_m2m_hostname="${API_HOSTNAME}" \
+      -var external_auth_hostname="${AUTH_HOSTNAME}"
+
+The command above:
+
+* Creates four Juju models: ``istio-system``, ``iam``, ``iam-core`` and ``kubeflow``.
+* Deploys the Istio ambient control plane into ``istio-system``.
+* Deploys the Canonical Identity Platform bundle into ``iam`` and its dependencies (including ``traefik``) into ``iam-core``.
+* Deploys CKF with the two ambient ingress gateways and the Identity Platform authentication charms into ``kubeflow``.
+* Deploys the ``github-profiles-automator`` charm, which syncs Kubeflow profiles from your PMR repository.
+* Sets the external hostname on the UI gateway (``ui.kubeflow.com``), the machine-to-machine gateway (``api.kubeflow.com``) and the Identity Platform ingress (``auth.kubeflow.com``).
+
+See `kubeflow-ambient-iam deployment <https://github.com/canonical/charmed-kubeflow-solutions/blob/feat/iam-integration/terraform-refactoring/tests/kubeflow-ambient-iam/README.md>`_ for more details.
+
+7. Verify all charms are in ``active`` status by monitoring the Juju models:
+
+.. code-block:: bash
+
+   juju status -m istio-system --watch 1s
+   juju status -m iam --watch 1s
+   juju status -m iam-core --watch 1s
+   juju status -m kubeflow --watch 1s
+
+.. note::
+
+   This may take up to some minutes, depending on the cluster's node specifications.
+
+.. _configure_dns_identity:
+
+--------------------------------------
+Configure DNS for the ingress gateways
+--------------------------------------
+
+The ingress gateways and the Identity Platform are exposed through ``LoadBalancer`` services using the hostnames you configured during deployment.
+For these hostnames to resolve, you need to configure DNS in two places:
+
+* **In-cluster DNS (CoreDNS)**, so that in-cluster workloads (for example, the authentication redirects between the gateways and the Identity Platform) can resolve the hostnames.
+* **Host DNS**, so that your browser can reach the gateways.
+
+1. Get the ``LoadBalancer`` IP addresses of the gateways and the Identity Platform ingress:
+
+.. code-block:: bash
+
+   UI_IP=$(kubectl -n kubeflow get svc istio-ingress-k8s-ui-istio \
+       -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+   API_IP=$(kubectl -n kubeflow get svc istio-ingress-k8s-m2m-istio \
+       -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+   AUTH_IP=$(kubectl -n iam-core get svc traefik-lb \
+       -o jsonpath='{.status.loadBalancer.ingress[0].ip}')
+   echo "UI   ui.kubeflow.com   -> $UI_IP"
+   echo "API  api.kubeflow.com  -> $API_IP"
+   echo "AUTH auth.kubeflow.com -> $AUTH_IP"
+
+Configure in-cluster DNS (CoreDNS)
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+2. Find the name of the CoreDNS ``ConfigMap`` in your cluster:
+
+.. code-block:: bash
+
+   kubectl -n kube-system get configmap | grep -i coredns
+
+The name depends on your K8s distribution:
+
+* On MicroK8s, it is ``coredns``.
+* On Canonical Kubernetes, it is ``ck-dns-coredns``.
+
+3. Edit the CoreDNS ``ConfigMap`` (replace ``coredns`` with the name found above):
+
+.. code-block:: bash
+
+   kubectl -n kube-system edit configmap coredns
+
+Add a ``hosts`` block inside the ``.:53 { ... }`` server block, just before the ``kubernetes`` plugin line, using the IP addresses from step 1:
+
+.. code-block:: text
+
+   hosts {
+       <UI_IP>   ui.kubeflow.com
+       <API_IP>  api.kubeflow.com
+       <AUTH_IP> auth.kubeflow.com
+       fallthrough
+   }
+
+.. note::
+
+   The ``fallthrough`` directive ensures that any query not matching these hostnames is still resolved by the rest of the CoreDNS configuration.
+
+4. Restart CoreDNS to apply the change (replace ``coredns`` with the matching deployment name, for example ``ck-dns-coredns`` on Canonical Kubernetes):
+
+.. code-block:: bash
+
+   kubectl -n kube-system rollout restart deployment coredns
+
+Configure host DNS
+~~~~~~~~~~~~~~~~~~~
+
+5. On the machine where you access the CKF dashboard from a browser, add the hostnames to ``/etc/hosts`` using the IP addresses from step 1:
+
+.. code-block:: bash
+
+   echo "$UI_IP ui.kubeflow.com"     | sudo tee -a /etc/hosts
+   echo "$API_IP api.kubeflow.com"   | sudo tee -a /etc/hosts
+   echo "$AUTH_IP auth.kubeflow.com" | sudo tee -a /etc/hosts
+
+.. _create_user_identity:
+
+---------------------
+Create a user
+---------------------
+
+The ``github-profiles-automator`` charm creates the Kubeflow profiles defined in your ``pmr.yaml`` file automatically.
+Each profile is owned by a user whose identity is provided by the Canonical Identity Platform.
+To log in and own a profile, create a matching user in Kratos.
+
+1. Create a Kratos user whose username matches the ``owner.name`` of a profile in your ``pmr.yaml`` file, using the Kratos `create-admin-account <https://charmhub.io/kratos/actions#create-admin-account>`_ action:
+
+.. code-block:: bash
+
+   juju run -m iam kratos/0 create-admin-account \
+      username=user1 \
+      email=user1@example.com
+
+.. note::
+
+   The ``owner.name`` in ``pmr.yaml`` maps to the Kratos ``username``, so both must be identical (for example, ``user1``).
+
+The action output includes a link that the user opens to set their account password.
+
+2. Confirm that the profile defined in your ``pmr.yaml`` file has been created:
+
+.. code-block:: bash
+
+   kubectl get profiles
+
+See :ref:`Manage profiles <manage_profiles>` for more details on managing profiles and the ``pmr.yaml`` format.
+
+---------------------
+Access CKF dashboard
+---------------------
+
+Once DNS is configured, you can access the CKF dashboard at ``https://ui.kubeflow.com``.
+You are redirected to the Canonical Identity Platform to authenticate with the user you created.
+
+The gateways and the Identity Platform are served with certificates issued by the ``self-signed-certificates`` charm by default.
+Because these certificates are not signed by a trusted certificate authority (CA), your browser warns that the connection is not trusted.
+
+* For a test or development deployment, accept the certificate warning in your browser to proceed to the login page.
+* For a production deployment, replace ``self-signed-certificates`` with a certificate provider backed by a trusted CA, so that browsers trust the certificates and no warning is shown.
+
+See the `Canonical Identity Platform documentation <https://canonical-identity.readthedocs-hosted.com/>`_ for more details on securing the Identity Platform.

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -107,7 +107,7 @@ The command above:
 * Deploys the ``github-profiles-automator`` charm, which syncs Kubeflow profiles from your PMR repository.
 * Sets the external hostname on the UI gateway (``ui.kubeflow.com``), the machine-to-machine gateway (``api.kubeflow.com``) and the Identity Platform ingress (``auth.kubeflow.com``).
 
-See `kubeflow-ambient-iam deployment <http://github.com/canonical/charmed-kubeflow-solutions/blob/main/terraform/tests/kubeflow-ambient-iam/README.md>`_ for more details.
+See `kubeflow-ambient-iam deployment <https://github.com/canonical/charmed-kubeflow-solutions/blob/main/terraform/tests/kubeflow-ambient-iam/README.md>`_ for more details.
 
 6. Verify all charms are in ``active`` status by monitoring the Juju models:
 

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -175,14 +175,14 @@ Configure in-cluster DNS (CoreDNS)
 
 The name depends on your K8s distribution:
 
-* On MicroK8s, it is ``coredns``.
 * On Canonical Kubernetes, it is ``ck-dns-coredns``.
+* On MicroK8s, it is ``coredns``.
 
-3. Edit the CoreDNS ``ConfigMap`` (replace ``coredns`` with the name found above):
+3. Edit the CoreDNS ``ConfigMap`` (replace ``ck-dns-coredns`` with the name found above if it differs):
 
 .. code-block:: bash
 
-   kubectl -n kube-system edit configmap coredns
+   kubectl -n kube-system edit configmap ck-dns-coredns
 
 Add a ``hosts`` block inside the ``.:53 { ... }`` server block, just before the ``kubernetes`` plugin line, using the IP addresses from step 1:
 
@@ -199,11 +199,11 @@ Add a ``hosts`` block inside the ``.:53 { ... }`` server block, just before the 
 
    The ``fallthrough`` directive ensures that any query not matching these hostnames is still resolved by the rest of the CoreDNS configuration.
 
-4. Restart CoreDNS to apply the change (replace ``coredns`` with the matching deployment name, for example ``ck-dns-coredns`` on Canonical Kubernetes):
+4. Restart CoreDNS to apply the change (replace ``ck-dns-coredns`` with the matching deployment name if it differs, for example ``coredns`` on MicroK8s):
 
 .. code-block:: bash
 
-   kubectl -n kube-system rollout restart deployment coredns
+   kubectl -n kube-system rollout restart deployment ck-dns-coredns
 
 Configure host DNS
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -26,9 +26,11 @@ The deployment spans four `Juju models <https://juju.is/docs/juju/model>`_:
 Requirements
 ---------------------
 
-* A K8s cluster version supported by Charmed Kubeflow (see :ref:`Supported versions <supported_kubeflow_versions>`) with a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ configured.
-* A load balancer provider on the cluster, so that the ingress gateways and the Identity Platform can be exposed through ``LoadBalancer`` services. For example, `MetalLB <https://metallb.io/>`_ on `MicroK8s`_.
-* A K8s cluster that meets the `Istio platform prerequisites`_ for the ambient mesh.
+* A K8s cluster that:
+
+  * is a version supported by Charmed Kubeflow (see :ref:`Supported versions <supported_kubeflow_versions>`), with a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ configured.
+  * has a load balancer provider, so that the ingress gateways and the Identity Platform can be exposed through ``LoadBalancer`` services. For example, `MetalLB <https://metallb.io/>`_ on `MicroK8s`_.
+  * meets the `Istio platform prerequisites`_ for the ambient mesh.
 * `Terraform CLI <https://developer.hashicorp.com/terraform/cli>`_. You can install it using the `snap`_.
 * `kubectl <https://kubernetes.io/docs/reference/kubectl/>`_ configured to access your cluster.
 

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -101,26 +101,18 @@ Create a repository (for example, ``https://github.com/example-org/kubeflow-pmr`
 
    Terraform automatically loads ``terraform.tfvars`` during ``terraform apply``.
 
-5. Define the external hostnames for the ingress gateways and the Identity Platform:
-
-.. code-block:: bash
-
-   UI_HOSTNAME="ui.kubeflow.com"
-   API_HOSTNAME="api.kubeflow.com"
-   AUTH_HOSTNAME="auth.kubeflow.com"
-
-.. note::
-
-   These hostnames do not need to be registered with a public DNS provider. You make them resolvable in the :ref:`Configure DNS for the ingress gateways <configure_dns_identity>` section below.
-
-6. Deploy the solution using Terraform as follows:
+5. Deploy the solution using Terraform, setting the external hostnames for the ingress gateways and the Identity Platform:
 
 .. code-block:: bash
 
    terraform apply \
-      -var external_ui_hostname="${UI_HOSTNAME}" \
-      -var external_m2m_hostname="${API_HOSTNAME}" \
-      -var external_auth_hostname="${AUTH_HOSTNAME}"
+      -var external_ui_hostname="ui.kubeflow.com" \
+      -var external_m2m_hostname="api.kubeflow.com" \
+      -var external_auth_hostname="auth.kubeflow.com"
+
+.. note::
+
+   These hostnames do not need to be registered with a public DNS provider. You make them resolvable in the :ref:`Configure DNS for the ingress gateways <configure_dns_identity>` section below.
 
 The command above:
 
@@ -133,7 +125,7 @@ The command above:
 
 See `kubeflow-ambient-iam deployment <https://github.com/canonical/charmed-kubeflow-solutions/blob/feat/iam-integration/terraform-refactoring/tests/kubeflow-ambient-iam/README.md>`_ for more details.
 
-7. Verify all charms are in ``active`` status by monitoring the Juju models:
+6. Verify all charms are in ``active`` status by monitoring the Juju models:
 
 .. code-block:: bash
 

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -82,6 +82,7 @@ Create a repository (for example, ``https://github.com/example-org/kubeflow-pmr`
 
 .. note::
 
+   The profile ``name`` (for example, ``ml-engineering``) is arbitrary; Kubeflow creates a namespace of the same name for the profile.
    The profile ``owner.name`` must match the Kratos username you create in the :ref:`Create a user <create_user_identity>` section.
    In this solution, the profile owner maps to the Identity Platform (Kratos) username, not to an email address.
 

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -169,22 +169,20 @@ For these hostnames to resolve, you need to configure DNS in two places:
 Configure in-cluster DNS (CoreDNS)
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-2. Find the name of the CoreDNS ``ConfigMap`` in your cluster:
+2. Find the CoreDNS ``ConfigMap`` name and store it in a variable to reuse it in the following steps:
 
 .. code-block:: bash
 
-   kubectl -n kube-system get configmap | grep -i coredns
+   COREDNS=$(kubectl -n kube-system get configmap -o name | grep coredns | head -n1 | cut -d/ -f2)
+   echo "$COREDNS"
 
-The name depends on your K8s distribution:
+The ``ConfigMap`` name depends on your K8s distribution: ``ck-dns-coredns`` on Canonical Kubernetes and ``coredns`` on MicroK8s.
 
-* On Canonical Kubernetes, it is ``ck-dns-coredns``.
-* On MicroK8s, it is ``coredns``.
-
-3. Edit the CoreDNS ``ConfigMap`` (replace ``ck-dns-coredns`` with the name found above if it differs):
+3. Edit the CoreDNS ``ConfigMap``:
 
 .. code-block:: bash
 
-   kubectl -n kube-system edit configmap ck-dns-coredns
+   kubectl -n kube-system edit configmap "$COREDNS"
 
 Add a ``hosts`` block inside the ``.:53 { ... }`` server block, just before the ``kubernetes`` plugin line, using the IP addresses from step 1:
 
@@ -201,11 +199,11 @@ Add a ``hosts`` block inside the ``.:53 { ... }`` server block, just before the 
 
    The ``fallthrough`` directive ensures that any query not matching these hostnames is still resolved by the rest of the CoreDNS configuration.
 
-4. Restart CoreDNS to apply the change (replace ``ck-dns-coredns`` with the matching deployment name if it differs, for example ``coredns`` on MicroK8s):
+4. Restart CoreDNS to apply the change:
 
 .. code-block:: bash
 
-   kubectl -n kube-system rollout restart deployment ck-dns-coredns
+   kubectl -n kube-system rollout restart deployment "$COREDNS"
 
 Configure host DNS
 ~~~~~~~~~~~~~~~~~~~

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -6,7 +6,7 @@ Install with Canonical Identity Platform using Terraform
 This guide describes how to install Charmed Kubeflow (CKF) integrated with the
 `Canonical Identity Platform <https://charmhub.io/topics/canonical-identity-platform>`_ using `Terraform`_.
 
-This solution runs CKF on the `Istio Ambient Mesh`_ and wires it to the Canonical Identity Platform
+This solution runs CKF on the `Istio Ambient Mesh`_ and integrates it with the Canonical Identity Platform
 (Hydra, Kratos and the Login UI) so that authentication is handled by the Identity Platform.
 
 .. note::
@@ -26,9 +26,9 @@ The deployment spans four `Juju models <https://juju.is/docs/juju/model>`_:
 Requirements
 ---------------------
 
-* A K8s cluster that:
+* A Kubernetes (K8s) cluster that:
 
-  * is a version supported by Charmed Kubeflow (see :ref:`Supported versions <supported_kubeflow_versions>`), with a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ configured.
+  * uses a version supported by Charmed Kubeflow (see :ref:`Supported versions <supported_kubeflow_versions>`), with a default `storage class <https://kubernetes.io/docs/concepts/storage/storage-classes/>`_ configured.
   * has a load balancer provider, so that the ingress gateways and the Identity Platform can be exposed through ``LoadBalancer`` services. For example, `MetalLB <https://metallb.io/>`_ on `MicroK8s`_.
   * meets the `Istio platform prerequisites`_ for the ambient mesh.
 * `Terraform CLI <https://developer.hashicorp.com/terraform/cli>`_. You can install it using the `snap`_.
@@ -39,7 +39,7 @@ Bootstrap Juju
 ---------------------
 
 CKF is deployed to Kubernetes with Juju.
-Before deployment, Juju must be bootstrapped to the K8s cluster.
+Before deployment, a Juju controller must be bootstrapped to the K8s cluster.
 See `Get started with Juju <https://documentation.ubuntu.com/juju/latest/tutorial/>`_ for more details.
 
 .. note::
@@ -52,7 +52,7 @@ Deploy CKF with the Identity Platform
 
 Deploy the solution as follows:
 
-1. Clone the repository and change directory to the solution module:
+1. Clone the ``charmed-kubeflow-solutions`` repository and change directory to the solution module:
 
 .. code-block:: bash
 
@@ -67,9 +67,9 @@ Deploy the solution as follows:
 
    terraform init
 
-3. Prepare a Profile Management Repository (PMR).
+3. Prepare a Profile Management Representation (PMR) in a Git repository.
 
-The ``github-profiles-automator`` charm keeps the Kubeflow profiles in sync with a ``pmr.yaml`` file stored in a GitHub repository.
+The ``github-profiles-automator`` charm keeps the Kubeflow profiles in sync with a YAML file stored in a GitHub repository.
 Create a repository (for example, ``https://github.com/example-org/kubeflow-pmr``) containing a ``pmr.yaml`` file at its root, such as:
 
 .. code-block:: yaml
@@ -82,7 +82,7 @@ Create a repository (for example, ``https://github.com/example-org/kubeflow-pmr`
 
 .. note::
 
-   The profile ``name`` (for example, ``ml-engineering``) is arbitrary; Kubeflow creates a namespace of the same name for the profile.
+   You can choose any ``name`` for the profile (for example, ``ml-engineering``); Kubeflow creates a namespace of the same name.
    The profile ``owner.name`` must match the Kratos username you create in the :ref:`Create a user <create_user_identity>` section.
    In this solution, the profile owner maps to the Identity Platform (Kratos) username, not to an email address.
 
@@ -100,6 +100,8 @@ Create a repository (for example, ``https://github.com/example-org/kubeflow-pmr`
 .. note::
 
    Terraform automatically loads ``terraform.tfvars`` during ``terraform apply``.
+
+   By default, the ``github-profiles-automator`` charm reads a file named ``pmr.yaml`` at the repository root. To use a different file or path, set ``pmr-yaml-path`` in ``github_profiles_automator_config``.
 
 5. Deploy the solution using Terraform, setting the external hostnames for the ingress gateways and the Identity Platform:
 
@@ -136,7 +138,7 @@ See `kubeflow-ambient-iam deployment <https://github.com/canonical/charmed-kubef
 
 .. note::
 
-   This may take up to some minutes, depending on the cluster's node specifications.
+   Deployment may take several minutes to complete, depending on the cluster's node specifications.
 
 .. _configure_dns_identity:
 
@@ -236,7 +238,7 @@ To log in and own a profile, create a matching user in Kratos.
 
 .. note::
 
-   The ``owner.name`` in ``pmr.yaml`` maps to the Kratos ``username``, so both must be identical (for example, ``user1``).
+   The ``owner.name`` in ``pmr.yaml`` maps to the Kratos ``username``, so they must be identical (for example, ``user1``).
 
 The action output includes a link that the user opens to set their account password.
 
@@ -256,7 +258,7 @@ Once DNS is configured, you can access the CKF dashboard at ``https://ui.kubeflo
 You are redirected to the Canonical Identity Platform to authenticate with the user you created.
 
 The gateways and the Identity Platform are served with certificates issued by the ``self-signed-certificates`` charm by default.
-Because these certificates are not signed by a trusted certificate authority (CA), your browser warns that the connection is not trusted.
+Because these certificates are not signed by a trusted certificate authority (CA), your browser may warn that the connection is not trusted.
 
 * For a test or development deployment, accept the certificate warning in your browser to proceed to the login page.
 * For a production deployment, replace ``self-signed-certificates`` with a certificate provider backed by a trusted CA, so that browsers trust the certificates and no warning is shown.

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -67,26 +67,10 @@ Deploy the solution as follows:
 
    terraform init
 
-3. Prepare a Profile Management Representation (PMR) in a Git repository.
+3. Create a Git repository for the Profile Management Representation (PMR).
 
-The ``github-profiles-automator`` charm keeps the Kubeflow profiles in sync with a YAML file stored in a GitHub repository.
-Create a repository (for example, ``https://github.com/example-org/kubeflow-pmr``) containing a ``pmr.yaml`` file at its root, such as:
-
-.. code-block:: yaml
-
-   profiles:
-   - name: ml-engineering
-     owner:
-       kind: User
-       name: user1
-
-.. note::
-
-   You can choose any ``name`` for the profile (for example, ``ml-engineering``); Kubeflow creates a namespace of the same name.
-   The profile ``owner.name`` must match the Kratos username you create in the :ref:`Create a user <create_user_identity>` section.
-   In this solution, the profile owner maps to the Identity Platform (Kratos) username, not to an email address.
-
-   See :ref:`Manage profiles <manage_profiles>` for the full ``pmr.yaml`` format, including contributors and resource quotas.
+The ``github-profiles-automator`` charm keeps the Kubeflow profiles in sync with a YAML file (the PMR) stored in a GitHub repository.
+Create an empty repository (for example, ``https://github.com/example-org/kubeflow-pmr``). You add the PMR file to it later, in the :ref:`Prepare the PMR <prepare_pmr_identity>` section, once you have created a user to own the profiles.
 
 4. Configure the ``github-profiles-automator`` charm to sync from your PMR repository by creating a ``terraform.tfvars`` file in the current directory:
 
@@ -139,6 +123,10 @@ See `kubeflow-ambient-iam deployment <https://github.com/canonical/charmed-kubef
 .. note::
 
    Deployment may take several minutes to complete, depending on the cluster's node specifications.
+
+.. note::
+
+   The ``github-profiles-automator`` charm remains in a ``blocked`` state until you add the PMR file to the repository, which you do in the :ref:`Prepare the PMR <prepare_pmr_identity>` section.
 
 .. _configure_dns_identity:
 
@@ -222,11 +210,10 @@ Configure host DNS
 Create a user
 ---------------------
 
-The ``github-profiles-automator`` charm creates the Kubeflow profiles defined in your ``pmr.yaml`` file automatically.
-Each profile is owned by a user whose identity is provided by the Canonical Identity Platform.
-To log in and own a profile, create a matching user in Kratos.
+Kubeflow profiles are owned by users whose identities are provided by the Canonical Identity Platform.
+Create a user in Kratos; you reference this user as the profile owner when you prepare the PMR in the next section.
 
-1. Create a Kratos user whose username matches the ``owner.name`` of a profile in your ``pmr.yaml`` file, using the Kratos `create-admin-account <https://charmhub.io/kratos/actions#create-admin-account>`_ action:
+Create a Kratos user using the `create-admin-account <https://charmhub.io/kratos/actions#create-admin-account>`_ action:
 
 .. code-block:: bash
 
@@ -234,25 +221,51 @@ To log in and own a profile, create a matching user in Kratos.
       username=user1 \
       email=user1@example.com
 
-.. note::
-
-   The ``owner.name`` in ``pmr.yaml`` maps to the Kratos ``username``, so they must be identical (for example, ``user1``).
-
 The action output includes a link that the user opens to set their account password.
 
-2. Confirm that the profile defined in your ``pmr.yaml`` file has been created:
+.. note::
+
+   Take note of the ``username`` (for example, ``user1``). You use it as the profile ``owner.name`` in the next section.
+
+.. _prepare_pmr_identity:
+
+---------------------
+Prepare the PMR
+---------------------
+
+Define a Kubeflow profile in the PMR, owned by the user you created.
+
+1. In the repository you created, add a ``pmr.yaml`` file at its root:
+
+.. code-block:: yaml
+
+   profiles:
+   - name: ml-engineering
+     owner:
+       kind: User
+       name: user1
+
+.. note::
+
+   You can choose any ``name`` for the profile (for example, ``ml-engineering``); Kubeflow creates a namespace of the same name.
+   The profile ``owner.name`` must match the Kratos ``username`` you created, so they must be identical (for example, ``user1``).
+   In this solution, the profile owner maps to the Identity Platform (Kratos) username, not to an email address.
+
+   See :ref:`Manage profiles <manage_profiles>` for the full ``pmr.yaml`` format, including contributors and resource quotas.
+
+2. Commit and push the file. The ``github-profiles-automator`` charm syncs the repository and creates the profile.
+
+3. Confirm that the profile has been created:
 
 .. code-block:: bash
 
    kubectl get profiles
 
-See :ref:`Manage profiles <manage_profiles>` for more details on managing profiles and the ``pmr.yaml`` format.
-
 ---------------------
 Access CKF dashboard
 ---------------------
 
-Once DNS is configured, you can access the CKF dashboard at ``https://ui.kubeflow.com``.
+Once DNS, the user, and the profile are ready, you can access the CKF dashboard at ``https://ui.kubeflow.com``.
 You are redirected to the Canonical Identity Platform to authenticate with the user you created.
 
 The gateways and the Identity Platform are served with certificates issued by the ``self-signed-certificates`` charm by default.

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -20,8 +20,6 @@ The deployment spans four `Juju models <https://juju.is/docs/juju/model>`_:
 * ``iam-core``: the Identity Platform dependencies (``postgresql-k8s``, ``traefik`` and ``self-signed-certificates``).
 * ``kubeflow``: the CKF applications, the two ambient ingress gateways (UI and machine-to-machine) and the Identity Platform authentication charms.
 
-.. TODO: Update this guide once the ``feat/iam-integration`` branch of charmed-kubeflow-solutions is merged, including the repository URL, branch and module path.
-
 ---------------------
 Requirements
 ---------------------
@@ -58,8 +56,8 @@ Deploy the solution as follows:
 
    git clone https://github.com/canonical/charmed-kubeflow-solutions
    cd charmed-kubeflow-solutions
-   git checkout feat/iam-integration
-   cd terraform-refactoring/tests/kubeflow-ambient-iam
+   git checkout main
+   cd terraform/tests/kubeflow-ambient-iam
 
 2. Initialise Terraform. The following command downloads all the required `Terraform modules <https://developer.hashicorp.com/terraform/language/modules>`_ and installs the Terraform `Juju provider <https://registry.terraform.io/providers/juju/juju/latest/docs>`_:
 
@@ -109,7 +107,7 @@ The command above:
 * Deploys the ``github-profiles-automator`` charm, which syncs Kubeflow profiles from your PMR repository.
 * Sets the external hostname on the UI gateway (``ui.kubeflow.com``), the machine-to-machine gateway (``api.kubeflow.com``) and the Identity Platform ingress (``auth.kubeflow.com``).
 
-See `kubeflow-ambient-iam deployment <https://github.com/canonical/charmed-kubeflow-solutions/blob/feat/iam-integration/terraform-refactoring/tests/kubeflow-ambient-iam/README.md>`_ for more details.
+See `kubeflow-ambient-iam deployment <http://github.com/canonical/charmed-kubeflow-solutions/blob/main/terraform/tests/kubeflow-ambient-iam/README.md>`_ for more details.
 
 6. Verify all charms are in ``active`` status by monitoring the Juju models:
 

--- a/docs/how-to/install/install-terraform-identity.rst
+++ b/docs/how-to/install/install-terraform-identity.rst
@@ -148,7 +148,7 @@ The ingress gateways and the Identity Platform are exposed through ``LoadBalance
 For these hostnames to resolve, you need to configure DNS in two places:
 
 * **In-cluster DNS (CoreDNS)**, so that in-cluster workloads (for example, the authentication redirects between the gateways and the Identity Platform) can resolve the hostnames.
-* **Host DNS**, so that your browser can reach the gateways.
+* **Host DNS**, so that the machine running your browser (the cluster host itself or a separate workstation) can reach the gateways.
 
 1. Get the ``LoadBalancer`` IP addresses of the gateways and the Identity Platform ingress:
 


### PR DESCRIPTION
Closes https://github.com/canonical/bundle-kubeflow/issues/1454

* Add a how-to guide for deploying CKF integrated with the Canonical Identity Platform on the Istio ambient mesh, including the four-model Terraform deployment, PMR/github-profiles-automator setup, DNS configuration for the ingress gateways, and creating a Kratos user.
* Add the guide to the install index toctree and add the required technical terms to the custom spelling wordlist.