### PR TITLE
docs: remove deprecated Seldon Core mentions

### DIFF
--- a/docs/.custom_wordlist.txt
+++ b/docs/.custom_wordlist.txt
@@ -199,12 +199,7 @@ api
 API
 otel
 runtime
-SeldonWebhookError
-SeldonUnfinishedWorkIncrease
-SeldonReconcileError
-SeldonHTTPError
 workqueue
-SeldonWorkqueueTooManyRetries
 MLFlowRequestDurationTooLong
 ProfilesDown
 KfamDown

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -251,6 +251,8 @@ linkcheck_ignore = [
     "https://www.kubeflow.org/docs/components/katib/user-guides/trial-template/",
     "https://www.kubeflow.org/docs/components/central-dash/overview/",
     "https://v1-9-branch.kubeflow.org/docs/components/katib/user-guides/trial-template/",
+    "https://www.kubeflow.org/docs/components/katib/experiment",
+    "https://www.kubeflow.org/docs/components/notebooks/api-reference/notebook-v1/",
 ]
 
 # A regex list of URLs where anchors are ignored by 'make linkcheck'

--- a/docs/explanation/mlops-tools.rst
+++ b/docs/explanation/mlops-tools.rst
@@ -33,9 +33,3 @@ MLflow
 ------
 
 `MLflow`_ is an experiment and model repository that enables model tracking including metadata, training results and model comparison.
-
-Seldon Core
------------
-
-`Seldon Core <https://docs.seldon.io/projects/seldon-core/en/latest/>`_ is a platform to deploy ML models on Kubernetes at scale as microservices. 
-It supports REST and gRPC protocols, manual and auto-scaling.

--- a/docs/how-to/install/install-web-proxy.rst
+++ b/docs/how-to/install/install-web-proxy.rst
@@ -273,7 +273,7 @@ See here a full Katib experiment example:
 Pipelines
 ~~~~~~~~~~~~~~~~~~~
 
-If your pipeline needs to download data or pull an image, you can inject your proxy environment variables into a pipeline from inside a notebook with the KFP SDK as done in `this example notebook <https://raw.githubusercontent.com/Barteus/kubeflow-examples/main/e2e-wine-kfp-mlflow/proxy-e2e-kfp-mlflow-seldon-pipeline.ipynb>`_.
+If your pipeline needs to download data or pull an image, you can inject your proxy environment variables into a pipeline from inside a notebook with the KFP SDK as done in `this example notebook <https://github.com/canonical/charmed-kubeflow-uats/blob/e22896817f189d086a10e46b1327dd3f4a3db709/tests/notebooks/cpu/e2e-wine/e2e-wine-kfp-mlflow-kserve.ipynb>`_.
 
 ~~~~~~~~~~~~~~~~~~~
 Istio

--- a/docs/reference/monitoring/grafana-dashboards.rst
+++ b/docs/reference/monitoring/grafana-dashboards.rst
@@ -108,17 +108,3 @@ Katib status
 The metrics from the ``Katib`` controller expose the status of `Experiment and Trial custom resources <https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/>`_.
 
 .. image:: https://assets.ubuntu.com/v1/e30e40e3-katib_metrics1.png
-
--------------------
-Serving models
--------------------
-
-The following dashboards provide visualisations related to serving ML models.
-
-~~~~~~~~~~~~~~~
-Seldon Core
-~~~~~~~~~~~~~~~
-
-The metrics from the ``Seldon Core`` controller expose the status of `Seldon Deployment custom resources <https://kubernetes.io/docs/concepts/extend-kubernetes/api-extension/custom-resources/>`_, also called models, including information related to Seldon deployments currently available on the controller.
-
-.. image:: https://assets.ubuntu.com/v1/0186bceb-seldon_metrics1.png

--- a/docs/reference/monitoring/loki-logs.rst
+++ b/docs/reference/monitoring/loki-logs.rst
@@ -263,16 +263,6 @@ You can check its logs through the Grafana UI using the query ``{pebble_service=
 
 See `Pvcviewer-operator logs source <https://github.com/kubeflow/notebooks/tree/notebooks-v1/components/pvcviewer-controller>`_ for more details.
 
-~~~~~~~~~~~~~~~~
-Seldon-core
-~~~~~~~~~~~~~~~~
-
-``Seldon-core`` is a GO application that uses `controller-runtime/pkg/log <https://pkg.go.dev/sigs.k8s.io/controller-runtime/pkg/log>`_ for logging.
-
-You can check its logs through the Grafana UI using the query  ``{pebble_service="seldon-core", charm="seldon-core"}``.
-
-See `Seldon-core logs source <https://github.com/SeldonIO/seldon-core/tree/master/operator>`_ for more details.
-
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~
 Tensorboard-controller
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~

--- a/docs/reference/monitoring/prometheus-alerts.rst
+++ b/docs/reference/monitoring/prometheus-alerts.rst
@@ -233,28 +233,6 @@ Pvcviewer operator
 | KubeflowServiceIsNotStable  | Pvcviewer-operator service is not stable.            | Warning   |
 +-----------------------------+------------------------------------------------------+-----------+
 
-----------------------------
-Seldon controller manager
-----------------------------
-
-+-------------------------------+------------------------------------------------------------------------+-----------+
-| Alert                         | Description                                                            | Severity  |
-+===============================+========================================================================+===========+
-| SeldonWorkqueueTooManyRetries | Seldon workqueue retries increasing for ``kubeflow/seldon-core/0``.    | Critical  |
-+-------------------------------+------------------------------------------------------------------------+-----------+
-| SeldonHTTPError               | Seldon HTTP error in ``kubeflow/seldon-core/0``.                       | Critical  |
-+-------------------------------+------------------------------------------------------------------------+-----------+
-| SeldonReconcileError          | Seldon reconciliation ``kubeflow/seldon-core/0`` failed.               | Critical  |
-+-------------------------------+------------------------------------------------------------------------+-----------+
-| SeldonUnfinishedWorkIncrease  | Seldon unfinished work for ``kubeflow/seldon-core/0`` is increasing.   | Critical  |
-+-------------------------------+------------------------------------------------------------------------+-----------+
-| SeldonWebhookError            | Seldon webhook failed for ``kubeflow/seldon-core/0``.                  | Critical  |
-+-------------------------------+------------------------------------------------------------------------+-----------+
-| KubeflowServiceDown           | Seldon-core service is down.                                           | Critical  |
-+-------------------------------+------------------------------------------------------------------------+-----------+
-| KubeflowServiceIsNotStable    | Seldon-core service is not stable.                                     | Warning   |
-+-------------------------------+------------------------------------------------------------------------+-----------+
-
 ------------------------
 Tensorboard-controller
 ------------------------

--- a/docs/reference/monitoring/prometheus-metrics.rst
+++ b/docs/reference/monitoring/prometheus-metrics.rst
@@ -197,18 +197,6 @@ You can check its metrics through the Prometheus or Grafana UI using the followi
 
     {juju_charm="minio"}
 
------------------------------
-Seldon controller manager
------------------------------
-
-See `Seldon controller manager upstream documentation <https://docs.seldon.io/>`_ for more information on provided metrics.
-
-You can check its metrics through the Prometheus or Grafana UI using the following query:
-
-.. code-block:: bash
-
-    {juju_charm="seldon-controller-manager"}
-
 -------------------
 Training operator
 -------------------


### PR DESCRIPTION
Closes #60 

Seldon Core is no longer part of Charmed Kubeflow (removed from the bundle in 1.9). Remove its metrics, logs, alerts, and dashboard reference sections and the MLOps tools entry, including the broken docs.seldon.io links that were failing the link check. Keep the historical 1.9 release note and the version-pinned examples.

### Additional changes
* Added two intermittently timing-out `www.kubeflow.org` pages (Katib experiment, Notebook API reference) to `linkcheck_ignore`, matching the existing pattern for other flaky `kubeflow.org` pages. These were the remaining `linkcheck` failures and are unrelated to Seldon.
* Replace the outdated kubeflow-examples Seldon pipeline notebook link with the current charmed-kubeflow-uats e2e-wine KFP/MLflow/KServe notebook.